### PR TITLE
DEVX-2143: Updates the Docker build process allowing entry script and writes spring config files

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,0 @@
-brew "kubernetes-cli"
-brew "k3d"
-brew "jq"
-brew "kustomize"
-brew "helm"
-brew "fluxctl"

--- a/apps/microservices-orders/orders-service/.gitignore
+++ b/apps/microservices-orders/orders-service/.gitignore
@@ -32,3 +32,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+config/

--- a/apps/microservices-orders/orders-service/Dockerfile
+++ b/apps/microservices-orders/orders-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jdk-slim
+WORKDIR /app
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} .
+COPY start.sh .
+ENTRYPOINT [ "/app/start.sh" ]

--- a/apps/microservices-orders/orders-service/Makefile
+++ b/apps/microservices-orders/orders-service/Makefile
@@ -20,13 +20,13 @@ clean:
 test:
 	@./gradlew test
 
-build:
+build: test
 	@./gradlew bootJar
 
 version:
 	@printf "%s" $(VERSION)
 
-package:
+package: build
 	@./gradlew bootBuildImage --imageName $(IMAGE_FULL_NAME)
 
 publish: package

--- a/apps/microservices-orders/orders-service/Makefile
+++ b/apps/microservices-orders/orders-service/Makefile
@@ -27,7 +27,7 @@ version:
 	@printf "%s" $(VERSION)
 
 package: build
-	@./gradlew bootBuildImage --imageName $(IMAGE_FULL_NAME)
+	@docker build -t $(IMAGE_FULL_NAME) .
 
 publish: package
 	@docker push $(IMAGE_FULL_NAME)

--- a/apps/microservices-orders/orders-service/build.gradle
+++ b/apps/microservices-orders/orders-service/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent.kafka-devops.microservices-orders'
-version = '10.0.1'
+version = '10.0.2'
 sourceCompatibility = '11'
 
 repositories {

--- a/apps/microservices-orders/orders-service/build.gradle
+++ b/apps/microservices-orders/orders-service/build.gradle
@@ -26,10 +26,6 @@ repositories {
 
 apply plugin: "com.commercehub.gradle.plugin.avro"
 
-ext {
-	set('springCloudVersion', "Hoxton.SR8")
-}
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/apps/microservices-orders/orders-service/src/main/resources/application.properties
+++ b/apps/microservices-orders/orders-service/src/main/resources/application.properties
@@ -1,23 +1,21 @@
-# Kafka
-spring.kafka.properties.sasl.mechanism=PLAIN
-spring.kafka.properties.request.timeout.ms=20000
+# Spring Kafka
 spring.kafka.properties.bootstrap.servers=localhost:9092
-spring.kafka.properties.retry.backoff.ms=500
 
-# Schema Registry
+# Spring Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=
 spring.kafka.properties.schema.registry.basic.auth.user.info=
 spring.kafka.properties.schema.registry.url=http://localhost:8081
 
-# Producer
+# Spring Kafka Producer
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 
-# Consumer
+# Spring Kafka Consumer
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 
-# Streams
+# Spring Kafka Streams
 spring.kafka.streams.application-id=order-table
 spring.kafka.streams.properties.default.key.serde=org.apache.kafka.common.serialization.Serdes$StringSerde
 spring.kafka.streams.properties.default.value.serde=io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde
+

--- a/apps/microservices-orders/orders-service/src/test/resources/application.properties
+++ b/apps/microservices-orders/orders-service/src/test/resources/application.properties
@@ -1,11 +1,5 @@
 # Kafka
-spring.kafka.properties.sasl.mechanism=PLAIN
-spring.kafka.properties.request.timeout.ms=20000
 spring.kafka.properties.bootstrap.servers=${spring.embedded.kafka.brokers}
-spring.kafka.properties.retry.backoff.ms=500
-# spring.kafka.properties.security.protocol=SASL_SSL
-# spring.kafka.properties.ssl.endpoint.identification.algorithm=https
-# spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule   required username=""   password="";
 
 # Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=

--- a/apps/microservices-orders/orders-service/start.sh
+++ b/apps/microservices-orders/orders-service/start.sh
@@ -17,7 +17,7 @@ mkdir -p config
 # Spring Kafka requires Kafka client properties to have a prefix, like the following:
 #   spring.kafka.properties.sasl.jass.config
 # This sed command will edit in place the properties file constructed above and prefix
-#   all the lines with spring.kafka.properties, skipping the comment lines
+#   all the lines with spring.kafka.properties, skipping the comment and blank lines
 sed -i '/^#/b; /^$/b; s/^/spring.kafka.properties./;' config/application.properties
 
 echo "starting orders-service"
@@ -25,5 +25,5 @@ cat config/application.properties 2>/dev/null
 
 sleep $STARTUP_DELAY
 
-# java -jar /app/orders-service-*.jar
+java -jar /app/orders-service-*.jar
 

--- a/apps/microservices-orders/orders-service/start.sh
+++ b/apps/microservices-orders/orders-service/start.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+STARTUP_DELAY=${STARTUP_DELAY:-0}
+
+mkdir -p config
+
+# The deployment mechanims might give us many properties files,
+#   one for each secret for example.  We want to pass the orders-service app
+#   a single properties file, so this bit will aggregate all the properties
+#   files into one, in a well known place Spring looks.
+#   Note: the application.properties name appears to be significant and has
+#     different behavior than if you override the spring.config.location setting
+[ -d "/etc/config/orders-service/" ] && {
+  for f in /etc/config/orders-service/*.properties; do (cat "${f}"; echo) >> config/application.properties; done
+}
+
+# Spring Kafka requires Kafka client properties to have a prefix, like the following:
+#   spring.kafka.properties.sasl.jass.config
+# This sed command will edit in place the properties file constructed above and prefix
+#   all the lines with spring.kafka.properties, skipping the comment lines
+sed -i '/^#/b; /^$/b; s/^/spring.kafka.properties./;' config/application.properties
+
+echo "starting orders-service"
+cat config/application.properties 2>/dev/null
+
+sleep $STARTUP_DELAY
+
+# java -jar /app/orders-service-*.jar
+


### PR DESCRIPTION
DEVX-2143: Updates Doker build process allowing entry script

    Needed to use a custom dockerfile for now until issues are resolved, detailed in
    https://github.com/confluentinc/kafka-devops/issues/38.

    The entry script will preprocess the properties files mounted by k8s so that they
    conform to the expected form for Spring