### PR TITLE
DEVX-2273: Updates default orders-service application-id and port

### DIFF
--- a/apps/microservices-orders/orders-service/build.gradle
+++ b/apps/microservices-orders/orders-service/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent.kafka-devops.microservices-orders'
-version = '10.0.2'
+version = '10.0.3'
 sourceCompatibility = '11'
 
 repositories {

--- a/apps/microservices-orders/orders-service/src/main/resources/application.properties
+++ b/apps/microservices-orders/orders-service/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.Str
 spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 
 # Spring Kafka Streams
-spring.kafka.streams.application-id=order-table
+spring.kafka.streams.application-id=OrdersService
 spring.kafka.streams.properties.default.key.serde=org.apache.kafka.common.serialization.Serdes$StringSerde
 spring.kafka.streams.properties.default.value.serde=io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde
 

--- a/apps/microservices-orders/orders-service/src/main/resources/application.yml
+++ b/apps/microservices-orders/orders-service/src/main/resources/application.yml
@@ -3,4 +3,4 @@ logging:
 orders-topic:
   name: orders
 server:
-  port: 9000
+  port: 18894


### PR DESCRIPTION
These defaults match the current settings for the legacy orders-service in kafka-devops. Choose this route instead of updating configurations as the app is used by kafka-devops exclusively now.