### PR TITLE
DEVX-2289: Simplifies configuration in orders-service

### DIFF
--- a/apps/microservices-orders/orders-service/build.gradle
+++ b/apps/microservices-orders/orders-service/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent.kafka-devops.microservices-orders'
-version = '10.0.4'
+version = '10.0.5'
 sourceCompatibility = '11'
 
 repositories {

--- a/apps/microservices-orders/orders-service/src/main/resources/application.properties
+++ b/apps/microservices-orders/orders-service/src/main/resources/application.properties
@@ -1,10 +1,31 @@
+
+# ###############################################
+# For Kafka, the following values can be
+# overridden by a 'traditional' Kafka
+# properties file
+bootstrap.servers=localhost:9092
+security.protocol=PLAINTEXT
+sasl.jaas.config=
+ssl.endpoint.identification.algorithm=
+sasl.mechanism=
+replication.factor=1
+schema.registry.url=http://localhost:8081
+basic.auth.credentials.source=
+schema.registry.basic.auth.user.info=
+# ###############################################
+
 # Spring Kafka
-spring.kafka.properties.bootstrap.servers=localhost:9092
+spring.kafka.properties.bootstrap.servers=${bootstrap.servers}
+spring.kafka.properties.security.protocol=${security.protocol}
+spring.kafka.properties.sasl.jaas.config=${sasl.jaas.config}
+spring.kafka.properties.sasl.mechanism=${sasl.mechanism}
+spring.kafka.properties.ssl.endpoint.identification.algorithm=${ssl.endpoint.identification.algorithm}
+spring.kafka.properties.replication.factor=${replication.factor}
 
 # Spring Schema Registry
-spring.kafka.properties.basic.auth.credentials.source=
-spring.kafka.properties.schema.registry.basic.auth.user.info=
-spring.kafka.properties.schema.registry.url=http://localhost:8081
+spring.kafka.properties.schema.registry.url=${schema.registry.url}
+spring.kafka.properties.basic.auth.credentials.source=${basic.auth.credentials.source}
+spring.kafka.properties.schema.registry.basic.auth.user.info=${schema.registry.basic.auth.user.info}
 
 # Spring Kafka Producer
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
This sets the stage for configuring entirely using Spring.  Right now a helper
script is required to preprocess some configurations.  However, using
active contexts w/ Spring, we should be able to load multiple configuration
files and use the ability to replace one config with value of another to remove
the preprocessing script from the application image