### PR TITLE
DEVX-2289: Migrates to Spring bootBuildImage for orders-service

### DIFF
--- a/apps/microservices-orders/orders-service/Makefile
+++ b/apps/microservices-orders/orders-service/Makefile
@@ -33,7 +33,7 @@ build: test
 	@./gradlew bootJar
 
 package: build
-	@docker build -t $(IMAGE_FULL_NAME) .
+	@./gradlew bootBuildImage --imageName $(IMAGE_FULL_NAME)
 	@docker tag $(IMAGE_FULL_NAME) $(IMAGE_SHA_NAME)
 
 publish: package

--- a/apps/microservices-orders/orders-service/build.gradle
+++ b/apps/microservices-orders/orders-service/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent.kafka-devops.microservices-orders'
-version = '10.0.7'
+version = '10.0.8'
 sourceCompatibility = '11'
 
 repositories {


### PR DESCRIPTION
docker packaging and bump to orders-service 10.0.8