### PR TITLE
GH-63: Removes Docker files from orders-service

### DIFF
--- a/apps/microservices-orders/orders-service/Dockerfile
+++ b/apps/microservices-orders/orders-service/Dockerfile
@@ -1,6 +1,0 @@
-FROM openjdk:11-jdk-slim
-WORKDIR /app
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} .
-COPY start.sh .
-ENTRYPOINT [ "/app/start.sh" ]

--- a/apps/microservices-orders/orders-service/start.sh
+++ b/apps/microservices-orders/orders-service/start.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-STARTUP_DELAY=${STARTUP_DELAY:-0}
-
-sleep $STARTUP_DELAY
-
-java -jar /app/orders-service-*.jar "$@"
-


### PR DESCRIPTION
These are no longer needed as the project was moved to using Spring
bootBuildJar which uses Buildpacks underneath.

Closes GH-63